### PR TITLE
Refactor channels

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -34,6 +34,7 @@ func (c *Channel) CreateChannel(channelName string, userIDs []string, initMsg Ms
 			channel.ID,
 			slack.MsgOptionText(initMsg.Body, false),
 			slack.MsgOptionAttachments(initMsg.Attachments...),
+			slack.MsgOptionBlocks(initMsg.Blocks...),
 			slack.MsgOptionEnableLinkUnfurl(),
 		)
 		if err != nil {

--- a/channel.go
+++ b/channel.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"errors"
-
 	"github.com/nlopes/slack"
 	"golang.org/x/sync/errgroup"
 )
@@ -17,10 +15,6 @@ func (c *Channel) CreateChannel(channelName string, userIDs []string, initMsg Ms
 	channel, err := c.UserClient.CreateChannel(channelName)
 	if err != nil {
 		return "", err
-	}
-
-	if channel == nil {
-		return "", errors.New("channel is nil")
 	}
 
 	for _, user := range userIDs {

--- a/channel.go
+++ b/channel.go
@@ -13,8 +13,8 @@ const ErrorInviteSelf = "cant_invite_self"
 const ErrorAlreadyArchived = "already_archived"
 
 // CreateChannel opens a new public channel and invites the provided list of member IDs, optionally posting an initial message
-func (c *Channel) CreateChannel(userIDs []string, initMsg Msg, postAsBot bool) (string, error) {
-	channel, err := c.UserClient.CreateChannel(c.ChannelName)
+func (c *Channel) CreateChannel(channelName string, userIDs []string, initMsg Msg, postAsBot bool) (string, error) {
+	channel, err := c.UserClient.CreateChannel(channelName)
 	if err != nil {
 		return "", err
 	}

--- a/slack.go
+++ b/slack.go
@@ -19,10 +19,8 @@ type Slack struct {
 
 // Channel is used in opening/interacting with public Slack channels
 type Channel struct {
-	UserClient  *slack.Client
-	BotClient   *slack.Client
-	ChannelName string
-	InitMsg     string
+	UserClient *slack.Client
+	BotClient  *slack.Client
 }
 
 // Shuffle is used in randmoizing a list of users and splitting them into


### PR DESCRIPTION
## Summary
- Take channel name and init msg out of Channels struct as this does not provide anything functionally. Can be passed in as args directly to methods requiring them.
- Remove redundant nil check
- Support blocks in `CreateChannel`