### PR TITLE
Add new message helper and update comments

### DIFF
--- a/mock_resp.go
+++ b/mock_resp.go
@@ -102,6 +102,27 @@ const postMsgResp = `{
     }
 }`
 
+const updateMsgResp = `{
+    "ok": true,
+    "channel": "C1H9RESGL",
+    "ts": "1503435956.000400",
+    "message": {
+        "text": "Here's a message for you",
+        "username": "ecto1",
+        "bot_id": "B19LU7CSY",
+        "attachments": [
+            {
+                "text": "This is an attachment",
+                "id": 1,
+                "fallback": "This is an attachment's fallback"
+            }
+        ],
+        "type": "message",
+        "subtype": "bot_message",
+        "ts": "1503435956.000247"
+    }
+}`
+
 const channelInfoResp = `{
     "ok": true,
     "channel": {


### PR DESCRIPTION
## Summary
The replace original/delete original helpers worked off of button callback using interactive attachments, but  does not work with blocks. Added a new helper method for `chat.update` that uses some common message options