### PR TITLE
Add date picker time parse helper

### DIFF
--- a/block.go
+++ b/block.go
@@ -6,31 +6,45 @@ import (
 	"github.com/nlopes/slack"
 )
 
-var (
-	cancelBtnTxt = slack.NewTextBlockObject(slack.PlainTextType, "Cancel", false, false)
-	ackBtnTxt    = slack.NewTextBlockObject(slack.PlainTextType, "Got it", false, false)
+const (
+	datePickTimeFmt = "2006-01-02"
 
 	CancelActionID = "cancel_action"
 	AckActionID    = "acknowledge_action"
-	CancelBtn      = NewButtonWithStyle(CancelActionID, "cancel", cancelBtnTxt, slack.StyleDanger)
-	AckBtn         = NewButtonWithStyle(AckActionID, "acknowledge", ackBtnTxt, slack.StylePrimary)
+)
+
+var (
+	cancelBtnTxt = slack.NewTextBlockObject(slack.PlainTextType, "Cancel", false, false)
+	ackBtnTxt    = slack.NewTextBlockObject(slack.PlainTextType, "Got it", false, false)
+	CancelBtn    = NewButtonWithStyle(CancelActionID, "cancel", cancelBtnTxt, slack.StyleDanger)
+	AckBtn       = NewButtonWithStyle(AckActionID, "acknowledge", ackBtnTxt, slack.StylePrimary)
 
 	DivBlock = slack.NewDividerBlock()
 )
 
+// NewButtonWithStyle returns a new ButtonBlockElement set to the designated style
 func NewButtonWithStyle(actionID, value string, textObj *slack.TextBlockObject, style slack.Style) *slack.ButtonBlockElement {
 	btn := slack.NewButtonBlockElement(actionID, value, textObj)
 	btn.WithStyle(style)
 	return btn
 }
 
+// NewDatePickerWithOpts returns a new DatePickerBlockElement initialized with
+// its date/placeholder text set as specified by one of the two parameters
 func NewDatePickerWithOpts(actionID string, placeholder *slack.TextBlockObject, initialDate time.Time) *slack.DatePickerBlockElement {
 	picker := slack.NewDatePickerBlockElement(actionID)
 	if placeholder != nil {
 		picker.Placeholder = placeholder
 		return picker
 	}
-	dateStr := initialDate.Format("2006-01-02")
+	dateStr := initialDate.Format(datePickTimeFmt)
 	picker.InitialDate = dateStr
 	return picker
+}
+
+// DateOptToTime parses the selected date opt back to time.Time, but owing to
+// its format will always initialize to zero time for everything more
+// granular than a day. Add time.Duration as needed in downstream packages
+func DateOptToTime(opt string) (time.Time, error) {
+	return time.Parse(datePickTimeFmt, opt)
 }

--- a/block_test.go
+++ b/block_test.go
@@ -108,3 +108,43 @@ func TestNewDatePickerAtTime(t *testing.T) {
 	}
 
 }
+
+func TestNewDateOptToTime(t *testing.T) {
+	now := time.Now()
+	dateOptStr := now.Format(datePickTimeFmt)
+	unrecognizedLayoutOptStr := now.Format(time.ANSIC)
+	expectedTime, err := time.Parse(datePickTimeFmt, dateOptStr)
+	if err != nil {
+		t.Fatalf("received unexpected error: %s", err)
+		return
+	}
+
+	testCases := []struct {
+		description string
+		opt         string
+		wantErr     bool
+	}{
+		{
+			description: "returns parsed time value with no error",
+			opt:         dateOptStr,
+		},
+		{
+			description: "unrecognized layout string causes error",
+			opt:         unrecognizedLayoutOptStr,
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			parsedTime, err := DateOptToTime(dateOptStr)
+			if err != nil && !tc.wantErr {
+				t.Fatalf("received unexpected error: %s", err)
+				return
+			}
+			if diff := pretty.Compare(parsedTime, expectedTime); diff != "" {
+				t.Fatalf("expected to receive time: %v, got: %v", expectedTime, parsedTime)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Added a helper to parse the selected date time opt back to `time.Time` from `string`. Also refactored `block.go` a bit for readability and added a new test