### PR TITLE
Wrap errors in complex methods for clarity

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -1,9 +1,8 @@
 package utils
 
 import (
-	"errors"
-
 	"github.com/nlopes/slack"
+	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/channel.go
+++ b/channel.go
@@ -21,13 +21,13 @@ var ErrNoUsersInWorkplace = errors.New("no users in workplace")
 func (c *Channel) CreateChannel(channelName string, userIDs []string, initMsg Msg, postAsBot bool) error {
 	channel, err := c.UserClient.CreateChannel(channelName)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to create new channel")
 	}
 
 	for _, user := range userIDs {
 		_, err = c.UserClient.InviteUserToChannel(channel.ID, user)
 		if err != nil && err.Error() != errInviteSelfMsg {
-			return err
+			return errors.Wrapf(err, "failed to invite user to channel")
 		}
 	}
 
@@ -45,7 +45,7 @@ func (c *Channel) CreateChannel(channelName string, userIDs []string, initMsg Ms
 			slack.MsgOptionEnableLinkUnfurl(),
 		)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to post message")
 		}
 	}
 
@@ -94,7 +94,6 @@ func (s *Slack) GetChannelMemberEmails(channelID string) ([]string, error) {
 		if err == nil {
 			allUsers = users
 		}
-
 		return err
 	})
 

--- a/channel_test.go
+++ b/channel_test.go
@@ -32,7 +32,7 @@ func TestCreateChannel(t *testing.T) {
 			inviteMembers:     []string{},
 			initMsg:           Msg{},
 			respChannelCreate: []byte(channelCreateErrResp),
-			wantErr:           "invalid_name_specials",
+			wantErr:           "failed to create new channel: invalid_name_specials",
 		},
 		{
 			description:       "successful channel creation including additional invites",
@@ -56,7 +56,7 @@ func TestCreateChannel(t *testing.T) {
 			initMsg:           Msg{},
 			respChannelCreate: []byte(channelCreateResp),
 			respInviteMembers: []byte(inviteMembersErrResp),
-			wantErr:           "cant_invite",
+			wantErr:           "failed to invite user to channel: cant_invite",
 		},
 		{
 			description:       "successful channel creation including additional invites, successful message post",
@@ -74,7 +74,7 @@ func TestCreateChannel(t *testing.T) {
 			respChannelCreate: []byte(channelCreateResp),
 			respInviteMembers: []byte(inviteMembersResp),
 			respPostMsg:       []byte(postMsgErrResp),
-			wantErr:           "too_many_attachments",
+			wantErr:           "failed to post message: too_many_attachments",
 		},
 	}
 

--- a/file.go
+++ b/file.go
@@ -3,7 +3,8 @@ package utils
 import (
 	"bytes"
 	"encoding/csv"
-	"errors"
+
+	"github.com/pkg/errors"
 
 	"github.com/nlopes/slack"
 )

--- a/file.go
+++ b/file.go
@@ -17,13 +17,13 @@ func DownloadAndReadCSV(userClient *slack.Client, urlPrivateDownload string) ([]
 	b := bytes.Buffer{}
 	err := userClient.GetFile(urlPrivateDownload, &b)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to download file")
 	}
 
 	r := csv.NewReader(&b)
 	rows, err := r.ReadAll()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to read CSV")
 	}
 
 	if len(rows) == 0 {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/kylelemons/godebug v1.1.0
 	github.com/nlopes/slack v0.5.1-0.20190605211732-a05dfd3f167d
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.8.1
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/tools v0.0.0-20190428024724-550556f78a90 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/nlopes/slack v0.5.1-0.20190605211732-a05dfd3f167d h1:ziZZlaAi8gvHe87RUuDh9kSerJl1pJGIika2qzP1bfk=
 github.com/nlopes/slack v0.5.1-0.20190605211732-a05dfd3f167d/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=


### PR DESCRIPTION
## Summary
Error messages that come from Slack are short and often cryptic, so this PR wraps them in a more explanatory error message for complex methods with more than one potential error message