### PR TITLE
Deprecate Slack receiver

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -18,6 +18,10 @@ var ErrNoUsersInWorkplace = errors.New("no users in workplace")
 
 // CreateChannel opens a new public channel and invites the provided list of member IDs, optionally posting an initial message
 func (c *Channel) CreateChannel(channelName string, userIDs []string, initMsg Msg, postAsBot bool) error {
+	if c.UserClient == nil {
+		return errors.New("method requires user client")
+	}
+
 	channel, err := c.UserClient.CreateChannel(channelName)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create new channel")
@@ -54,6 +58,10 @@ func (c *Channel) CreateChannel(channelName string, userIDs []string, initMsg Ms
 }
 
 func (c *Channel) InviteUsers(userIDs []string) error {
+	if c.UserClient == nil {
+		return errors.New("method requires user client")
+	}
+
 	for _, user := range userIDs {
 		_, err := c.UserClient.InviteUserToChannel(c.ChannelID, user)
 		if err != nil && err.Error() != errInviteSelfMsg {
@@ -64,9 +72,39 @@ func (c *Channel) InviteUsers(userIDs []string) error {
 	return nil
 }
 
+// LeaveChannels allows the user whose token was used to create the API client to leave multiple channels
+func (c *Channel) LeaveChannels(channelIDs []string) error {
+	if c.UserClient == nil {
+		return errors.New("method requires user client")
+	}
+
+	for _, channelID := range channelIDs {
+		_, err := c.UserClient.LeaveChannel(channelID)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ArchiveChannels allows the user whose token was used to create the API client to archive multiple channels
+func (c *Channel) ArchiveChannels(channelIDs []string) error {
+	if c.UserClient == nil {
+		return errors.New("method requires user client")
+	}
+
+	for _, channelID := range channelIDs {
+		err := c.UserClient.ArchiveChannel(channelID)
+		if err != nil && err.Error() != errAlreadyArchivedMsg {
+			return err
+		}
+	}
+	return nil
+}
+
 // GetChannelMembers returns a list of members for a given channel
-func (c *Channel) GetChannelMembers() ([]string, error) {
-	channel, err := c.UserClient.GetChannelInfo(c.ChannelID)
+func GetChannelMembers(client *slack.Client, channelID string) ([]string, error) {
+	channel, err := client.GetChannelInfo(channelID)
 	if err != nil {
 		return nil, err
 	}
@@ -105,26 +143,4 @@ func GetChannelMemberEmails(client *slack.Client, channelID string) ([]string, e
 	}
 
 	return toEmails(allUsers, memberIDs), nil
-}
-
-// LeaveChannels allows the user whose token was used to create the API client to leave multiple channels
-func LeaveChannels(client *slack.Client, channelIDs []string) error {
-	for _, channelID := range channelIDs {
-		_, err := client.LeaveChannel(channelID)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// ArchiveChannels allows the user whose token was used to create the API client to archive multiple channels
-func ArchiveChannels(client *slack.Client, channelIDs []string) error {
-	for _, channelID := range channelIDs {
-		err := client.ArchiveChannel(channelID)
-		if err != nil && err.Error() != errAlreadyArchivedMsg {
-			return err
-		}
-	}
-	return nil
 }

--- a/channel.go
+++ b/channel.go
@@ -75,13 +75,13 @@ func (c *Channel) GetChannelMembers() ([]string, error) {
 }
 
 // GetChannelMemberEmails returns a list of emails for members of a given channel
-func (s *Slack) GetChannelMemberEmails(channelID string) ([]string, error) {
+func GetChannelMemberEmails(client *slack.Client, channelID string) ([]string, error) {
 	var eg errgroup.Group
 	var memberIDs []string
 	var allUsers []slack.User
 
 	eg.Go(func() error {
-		channel, err := s.Client.GetChannelInfo(channelID)
+		channel, err := client.GetChannelInfo(channelID)
 		if err == nil {
 			memberIDs = channel.Members
 		}
@@ -89,7 +89,7 @@ func (s *Slack) GetChannelMemberEmails(channelID string) ([]string, error) {
 	})
 
 	eg.Go(func() error {
-		users, err := s.getAll()
+		users, err := getAll(client)
 		if err == nil {
 			allUsers = users
 		}
@@ -108,9 +108,9 @@ func (s *Slack) GetChannelMemberEmails(channelID string) ([]string, error) {
 }
 
 // LeaveChannels allows the user whose token was used to create the API client to leave multiple channels
-func (s *Slack) LeaveChannels(channelIDs []string) error {
+func LeaveChannels(client *slack.Client, channelIDs []string) error {
 	for _, channelID := range channelIDs {
-		_, err := s.Client.LeaveChannel(channelID)
+		_, err := client.LeaveChannel(channelID)
 		if err != nil {
 			return err
 		}
@@ -119,9 +119,9 @@ func (s *Slack) LeaveChannels(channelIDs []string) error {
 }
 
 // ArchiveChannels allows the user whose token was used to create the API client to archive multiple channels
-func (s *Slack) ArchiveChannels(channelIDs []string) error {
+func ArchiveChannels(client *slack.Client, channelIDs []string) error {
 	for _, channelID := range channelIDs {
-		err := s.Client.ArchiveChannel(channelID)
+		err := client.ArchiveChannel(channelID)
 		if err != nil && err.Error() != errAlreadyArchivedMsg {
 			return err
 		}

--- a/channel_test.go
+++ b/channel_test.go
@@ -97,7 +97,6 @@ func TestCreateChannel(t *testing.T) {
 			client := slack.New("x012345", slack.OptionAPIURL(fmt.Sprintf("%v/", testServ.URL)))
 			channel := Channel{
 				UserClient: client,
-				BotClient:  nil,
 			}
 
 			err := channel.CreateChannel("general", tc.inviteMembers, tc.initMsg, false)
@@ -163,7 +162,6 @@ func TestInviteUsers(t *testing.T) {
 			client := slack.New("x012345", slack.OptionAPIURL(fmt.Sprintf("%v/", testServ.URL)))
 			channel := Channel{
 				UserClient: client,
-				BotClient:  nil,
 				ChannelID:  "C1H9RESGL",
 			}
 
@@ -217,12 +215,8 @@ func TestGetChannelMembers(t *testing.T) {
 			defer testServ.Close()
 
 			client := slack.New("x012345", slack.OptionAPIURL(fmt.Sprintf("%v/", testServ.URL)))
-			channel := Channel{
-				UserClient: client,
-				ChannelID:  "C1H9RESGL",
-			}
 
-			members, err := channel.GetChannelMembers()
+			members, err := GetChannelMembers(client, "C1H9RESGL")
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -357,8 +351,11 @@ func TestLeaveChannels(t *testing.T) {
 			defer testServ.Close()
 
 			client := slack.New("x012345", slack.OptionAPIURL(fmt.Sprintf("%v/", testServ.URL)))
+			channel := Channel{
+				UserClient: client,
+			}
 
-			err := LeaveChannels(client, []string{"C1H9RESGL"})
+			err := channel.LeaveChannels([]string{"C1H9RESGL"})
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -410,8 +407,11 @@ func TestArchiveChannels(t *testing.T) {
 			defer testServ.Close()
 
 			client := slack.New("x012345", slack.OptionAPIURL(fmt.Sprintf("%v/", testServ.URL)))
+			channel := Channel{
+				UserClient: client,
+			}
 
-			err := ArchiveChannels(client, []string{"C1H9RESGL"})
+			err := channel.ArchiveChannels([]string{"C1H9RESGL"})
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)

--- a/channel_test.go
+++ b/channel_test.go
@@ -296,11 +296,8 @@ func TestGetChannelMemberEmails(t *testing.T) {
 			defer testServ.Close()
 
 			client := slack.New("x012345", slack.OptionAPIURL(fmt.Sprintf("%v/", testServ.URL)))
-			slackClient := Slack{
-				Client: client,
-			}
 
-			emails, err := slackClient.GetChannelMemberEmails("C1H9RESGL")
+			emails, err := GetChannelMemberEmails(client, "C1H9RESGL")
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -360,11 +357,8 @@ func TestLeaveChannels(t *testing.T) {
 			defer testServ.Close()
 
 			client := slack.New("x012345", slack.OptionAPIURL(fmt.Sprintf("%v/", testServ.URL)))
-			slackClient := Slack{
-				Client: client,
-			}
 
-			err := slackClient.LeaveChannels([]string{"C1H9RESGL"})
+			err := LeaveChannels(client, []string{"C1H9RESGL"})
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -416,11 +410,8 @@ func TestArchiveChannels(t *testing.T) {
 			defer testServ.Close()
 
 			client := slack.New("x012345", slack.OptionAPIURL(fmt.Sprintf("%v/", testServ.URL)))
-			slackClient := Slack{
-				Client: client,
-			}
 
-			err := slackClient.ArchiveChannels([]string{"C1H9RESGL"})
+			err := ArchiveChannels(client, []string{"C1H9RESGL"})
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/nlopes/slack v0.5.1-0.20190605211732-a05dfd3f167d h1:ziZZlaAi8gvHe87RUuDh9kSerJl1pJGIika2qzP1bfk=
 github.com/nlopes/slack v0.5.1-0.20190605211732-a05dfd3f167d/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=

--- a/slack.go
+++ b/slack.go
@@ -11,11 +11,6 @@ var ErrNoSecret = errors.New("no signing secret found in context")
 
 type signingSecretKey struct{}
 
-// Slack is a general purpose struct used when only the client is required
-type Slack struct {
-	Client *slack.Client
-}
-
 // Channel is used in opening/interacting with a single Slack channel
 type Channel struct {
 	UserClient *slack.Client

--- a/user.go
+++ b/user.go
@@ -6,8 +6,8 @@ import (
 
 // EmailsToSlackIDs takes in an array of email addresses and finds the IDs of
 // any workplace members with those emails
-func (s *Slack) EmailsToSlackIDs(emails []string) ([]string, error) {
-	users, err := s.getAll()
+func EmailsToSlackIDs(client *slack.Client, emails []string) ([]string, error) {
+	users, err := getAll(client)
 	if err != nil {
 		return nil, err
 	}
@@ -21,8 +21,8 @@ func (s *Slack) EmailsToSlackIDs(emails []string) ([]string, error) {
 
 // EmailToSlackIDsInclusive takes in an array of email addresses, finds the IDs
 // of any workplace members with those emails, and returns both values
-func (s *Slack) EmailsToSlackIDsInclusive(emails []string) ([][]string, error) {
-	users, err := s.getAll()
+func EmailsToSlackIDsInclusive(client *slack.Client, emails []string) ([][]string, error) {
+	users, err := getAll(client)
 	if err != nil {
 		return nil, err
 	}
@@ -73,8 +73,8 @@ func toEmails(users []slack.User, userIDs []string) []string {
 	return emails
 }
 
-func (s *Slack) getAll() ([]slack.User, error) {
-	users, err := s.Client.GetUsers()
+func getAll(client *slack.Client) ([]slack.User, error) {
+	users, err := client.GetUsers()
 	if err != nil {
 		return nil, err
 	}

--- a/user_test.go
+++ b/user_test.go
@@ -40,11 +40,8 @@ func TestEmailsToSlackIDs(t *testing.T) {
 			defer testServ.Close()
 
 			client := slack.New("x012345", slack.OptionAPIURL(fmt.Sprintf("%v/", testServ.URL)))
-			slackClient := Slack{
-				Client: client,
-			}
 
-			ids, err := slackClient.EmailsToSlackIDs(tc.emails)
+			ids, err := EmailsToSlackIDs(client, tc.emails)
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -107,11 +104,8 @@ func TestEmailsToSlackIDsInclusive(t *testing.T) {
 			defer testServ.Close()
 
 			client := slack.New("x012345", slack.OptionAPIURL(fmt.Sprintf("%v/", testServ.URL)))
-			slackClient := Slack{
-				Client: client,
-			}
 
-			idEmailPairs, err := slackClient.EmailsToSlackIDsInclusive(tc.emails)
+			idEmailPairs, err := EmailsToSlackIDsInclusive(client, tc.emails)
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Summary
- `Slack` receiver is ultimately not useful so deprecating and passing in client instead
- Refactor channel methods once again to enforce use of `UserClient` where bot privileges do not suffice