### PR TITLE
Refactor message functionality

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -116,7 +116,6 @@ func TestNewDateOptToTime(t *testing.T) {
 	expectedTime, err := time.Parse(datePickTimeFmt, dateOptStr)
 	if err != nil {
 		t.Fatalf("received unexpected error: %s", err)
-		return
 	}
 
 	testCases := []struct {
@@ -140,7 +139,6 @@ func TestNewDateOptToTime(t *testing.T) {
 			parsedTime, err := DateOptToTime(dateOptStr)
 			if err != nil && !tc.wantErr {
 				t.Fatalf("received unexpected error: %s", err)
-				return
 			}
 			if diff := pretty.Compare(parsedTime, expectedTime); diff != "" {
 				t.Fatalf("expected to receive time: %v, got: %v", expectedTime, parsedTime)

--- a/channel_test.go
+++ b/channel_test.go
@@ -24,56 +24,56 @@ func TestCreateChannel(t *testing.T) {
 			description:       "successful channel creation, no additional invites",
 			inviteMembers:     []string{},
 			initMsg:           Msg{},
-			respChannelCreate: []byte(channelCreateResp),
+			respChannelCreate: []byte(mockChannelCreateResp),
 			wantID:            "C0DEL09A5",
 		},
 		{
 			description:       "err creating channel",
 			inviteMembers:     []string{},
 			initMsg:           Msg{},
-			respChannelCreate: []byte(channelCreateErrResp),
+			respChannelCreate: []byte(mockChannelCreateErrResp),
 			wantErr:           "failed to create new channel: invalid_name_specials",
 		},
 		{
 			description:       "successful channel creation including additional invites",
 			inviteMembers:     []string{"UABC123EFG"},
 			initMsg:           Msg{},
-			respChannelCreate: []byte(channelCreateResp),
-			respInviteMembers: []byte(inviteMembersResp),
+			respChannelCreate: []byte(mockChannelCreateResp),
+			respInviteMembers: []byte(mockInviteMembersResp),
 			wantID:            "C0DEL09A5",
 		},
 		{
 			description:       "successful channel creation, inviting members including self but no error returned",
 			inviteMembers:     []string{"U0G9QF9C6"},
 			initMsg:           Msg{},
-			respChannelCreate: []byte(channelCreateResp),
-			respInviteMembers: []byte(cantInviteSelfErrResp),
+			respChannelCreate: []byte(mockChannelCreateResp),
+			respInviteMembers: []byte(mockCantInviteSelfErrResp),
 			wantID:            "C0DEL09A5",
 		},
 		{
 			description:       "err inviting members",
 			inviteMembers:     []string{"UABC123EFG"},
 			initMsg:           Msg{},
-			respChannelCreate: []byte(channelCreateResp),
-			respInviteMembers: []byte(inviteMembersErrResp),
+			respChannelCreate: []byte(mockChannelCreateResp),
+			respInviteMembers: []byte(mockInviteMembersErrResp),
 			wantErr:           "failed to invite user to channel: cant_invite",
 		},
 		{
 			description:       "successful channel creation including additional invites, successful message post",
 			inviteMembers:     []string{"UABC123EFG"},
 			initMsg:           Msg{Body: "Hey!"},
-			respChannelCreate: []byte(channelCreateResp),
-			respInviteMembers: []byte(inviteMembersResp),
-			respPostMsg:       []byte(postMsgResp),
+			respChannelCreate: []byte(mockChannelCreateResp),
+			respInviteMembers: []byte(mockInviteMembersResp),
+			respPostMsg:       []byte(mockPostMsgResp),
 			wantID:            "C0DEL09A5",
 		},
 		{
 			description:       "successful channel creation including additional invites, failure to post init message",
 			inviteMembers:     []string{"UABC123EFG"},
 			initMsg:           Msg{Body: "Hey!"},
-			respChannelCreate: []byte(channelCreateResp),
-			respInviteMembers: []byte(inviteMembersResp),
-			respPostMsg:       []byte(postMsgErrResp),
+			respChannelCreate: []byte(mockChannelCreateResp),
+			respInviteMembers: []byte(mockInviteMembersResp),
+			respPostMsg:       []byte(mockPostMsgErrResp),
 			wantErr:           "failed to post message: too_many_attachments",
 		},
 	}
@@ -103,17 +103,14 @@ func TestCreateChannel(t *testing.T) {
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
-				return
 			}
 
 			if tc.wantErr != "" {
 				if err == nil {
 					t.Fatal("expected error but did not receive one")
-					return
 				}
 				if err.Error() != tc.wantErr {
 					t.Fatalf("expected to receive error: %s, got: %s", tc.wantErr, err)
-					return
 				}
 			}
 
@@ -134,17 +131,17 @@ func TestInviteUsers(t *testing.T) {
 		{
 			description:       "successful invite of users",
 			inviteMembers:     []string{"UABC123EFG"},
-			respInviteMembers: []byte(inviteMembersResp),
+			respInviteMembers: []byte(mockInviteMembersResp),
 		},
 		{
 			description:       "successful invite, no error returned for invite members resp",
 			inviteMembers:     []string{"UABC123EFG", "U0G9QF9C6"},
-			respInviteMembers: []byte(inviteMembersResp),
+			respInviteMembers: []byte(mockInviteMembersResp),
 		},
 		{
 			description:       "expect error",
 			inviteMembers:     []string{"UABC123EFG"},
-			respInviteMembers: []byte(inviteMembersErrResp),
+			respInviteMembers: []byte(mockInviteMembersErrResp),
 			wantErr:           "cant_invite",
 		},
 	}
@@ -169,13 +166,11 @@ func TestInviteUsers(t *testing.T) {
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
-				return
 			}
 
 			if tc.wantErr != "" {
 				if err == nil {
 					t.Fatal("expected error but did not receive one")
-					return
 				}
 				if err.Error() != tc.wantErr {
 					t.Fatalf("expected to receive error: %s, got: %s", tc.wantErr, err)
@@ -194,12 +189,12 @@ func TestGetChannelMembers(t *testing.T) {
 	}{
 		{
 			description:     "successful retrieval of member IDs",
-			respChannelInfo: []byte(channelInfoResp),
+			respChannelInfo: []byte(mockChannelInfoResp),
 			wantIDs:         []string{"U0G9QF9C6", "U1QNSQB9U"},
 		},
 		{
 			description:     "failure to retrieve member IDs",
-			respChannelInfo: []byte(channelInfoErrResp),
+			respChannelInfo: []byte(mockChannelInfoErrResp),
 			wantErr:         "channel_not_found",
 		},
 	}
@@ -220,23 +215,19 @@ func TestGetChannelMembers(t *testing.T) {
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
-				return
 			}
 
 			if tc.wantErr != "" {
 				if err == nil {
 					t.Fatal("expected error but did not receive one")
-					return
 				}
 				if err.Error() != tc.wantErr {
 					t.Fatalf("expected to receive error: %s, got: %s", tc.wantErr, err)
-					return
 				}
 			}
 
 			if len(members) != len(tc.wantIDs) {
 				t.Fatalf("expected to receive %v ids, got %v instead", len(tc.wantIDs), len(members))
-				return
 			}
 
 			for i, member := range members {
@@ -258,20 +249,20 @@ func TestGetChannelMemberEmails(t *testing.T) {
 	}{
 		{
 			description:     "successful retrieval of member emails",
-			respChannelInfo: []byte(channelInfoResp),
-			respUsersList:   []byte(usersListResp),
+			respChannelInfo: []byte(mockChannelInfoResp),
+			respUsersList:   []byte(mockUsersListResp),
 			wantEmails:      []string{"spengler@ghostbusters.example.com"},
 		},
 		{
 			description:     "failure to retrieve channel info",
-			respChannelInfo: []byte(channelInfoErrResp),
-			respUsersList:   []byte(usersListResp),
+			respChannelInfo: []byte(mockChannelInfoErrResp),
+			respUsersList:   []byte(mockUsersListResp),
 			wantErr:         "channel_not_found",
 		},
 		{
 			description:     "failure to retrieve user list",
-			respChannelInfo: []byte(channelInfoResp),
-			respUsersList:   []byte(usersListErrResp),
+			respChannelInfo: []byte(mockChannelInfoResp),
+			respUsersList:   []byte(mockUsersListErrResp),
 			wantErr:         "invalid_cursor",
 		},
 	}
@@ -295,23 +286,19 @@ func TestGetChannelMemberEmails(t *testing.T) {
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
-				return
 			}
 
 			if tc.wantErr != "" {
 				if err == nil {
 					t.Fatal("expected error but did not receive one")
-					return
 				}
 				if err.Error() != tc.wantErr {
 					t.Fatalf("expected to receive error: %s, got: %s", tc.wantErr, err)
-					return
 				}
 			}
 
 			if len(emails) != len(tc.wantEmails) {
 				t.Fatalf("expected to receive %v emails, got %v instead", len(tc.wantEmails), len(emails))
-				return
 			}
 
 			for i, email := range emails {
@@ -331,11 +318,11 @@ func TestLeaveChannels(t *testing.T) {
 	}{
 		{
 			description:       "successfully left channels",
-			respLeaveChannels: []byte(channelsLeaveResp),
+			respLeaveChannels: []byte(mockSuccessResp),
 		},
 		{
 			description:       "failure to leave channels",
-			respLeaveChannels: []byte(channelsLeaveErrResp),
+			respLeaveChannels: []byte(mockChannelsLeaveErrResp),
 			wantErr:           "invalid_auth",
 		},
 	}
@@ -359,13 +346,11 @@ func TestLeaveChannels(t *testing.T) {
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
-				return
 			}
 
 			if tc.wantErr != "" {
 				if err == nil {
 					t.Fatal("expected error but did not receive one")
-					return
 				}
 				if err.Error() != tc.wantErr {
 					t.Fatalf("expected to receive error: %s, got: %s", tc.wantErr, err)
@@ -383,15 +368,15 @@ func TestArchiveChannels(t *testing.T) {
 	}{
 		{
 			description:         "successfully archived channels",
-			respArchiveChannels: []byte(channelsArchiveResp),
+			respArchiveChannels: []byte(mockSuccessResp),
 		},
 		{
 			description:         "no error returned for already archived channel",
-			respArchiveChannels: []byte(channelAlreadyArchivedErrResp),
+			respArchiveChannels: []byte(mockChannelAlreadyArchivedErrResp),
 		},
 		{
 			description:         "failure to archive channels",
-			respArchiveChannels: []byte(channelsArchiveErrResp),
+			respArchiveChannels: []byte(mockChannelsArchiveErrResp),
 			wantErr:             "invalid_auth",
 		},
 	}
@@ -415,13 +400,11 @@ func TestArchiveChannels(t *testing.T) {
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
-				return
 			}
 
 			if tc.wantErr != "" {
 				if err == nil {
 					t.Fatal("expected error but did not receive one")
-					return
 				}
 				if err.Error() != tc.wantErr {
 					t.Fatalf("expected to receive error: %s, got: %s", tc.wantErr, err)

--- a/file_test.go
+++ b/file_test.go
@@ -51,7 +51,6 @@ func TestDownloadAndReadCSV(t *testing.T) {
 
 		if diff := pretty.Compare(tc.wantRows, rows); diff != "" {
 			t.Fatalf("expected to receive rows: %v, got: %v", tc.wantRows, rows)
-			return
 		}
 
 		if diff := pretty.Compare(tc.wantErr, err); diff != "" {

--- a/message.go
+++ b/message.go
@@ -15,19 +15,21 @@ type Msg struct {
 	AsUser      bool
 }
 
-// PostMsg sends the provided message to the channel designated by channelID
-func PostMsg(client *slack.Client, msg Msg, channelID string) (string, error) {
-	opts := []slack.MsgOption{
+func getCommonOpts(msg Msg) []slack.MsgOption {
+	return []slack.MsgOption{
 		slack.MsgOptionText(msg.Body, false),
 		slack.MsgOptionBlocks(msg.Blocks...),
 		slack.MsgOptionAttachments(msg.Attachments...),
 		slack.MsgOptionAsUser(msg.AsUser),
 		slack.MsgOptionEnableLinkUnfurl(),
 	}
+}
 
+// PostMsg sends the provided message to the channel designated by channelID
+func PostMsg(client *slack.Client, msg Msg, channelID string) (string, error) {
 	_, ts, err := client.PostMessage(
 		channelID,
-		opts...,
+		getCommonOpts(msg)...,
 	)
 
 	if err != nil {
@@ -54,7 +56,7 @@ func PostThreadMsg(client *slack.Client, msg Msg, channelID string, threadTs str
 func PostEphemeralMsg(client *slack.Client, msg Msg, channelID, userID string) error {
 	_, _, err := client.PostMessage(
 		channelID,
-		slack.MsgOptionPostEphemeral(userID),
+		append(getCommonOpts(msg), slack.MsgOptionPostEphemeral(userID))...,
 	)
 
 	return err
@@ -62,18 +64,10 @@ func PostEphemeralMsg(client *slack.Client, msg Msg, channelID, userID string) e
 
 // UpdateMsg updates the provided message in the channel designated by channelID
 func UpdateMsg(client *slack.Client, msg Msg, channelID, timestamp string) error {
-	opts := []slack.MsgOption{
-		slack.MsgOptionText(msg.Body, false),
-		slack.MsgOptionBlocks(msg.Blocks...),
-		slack.MsgOptionAttachments(msg.Attachments...),
-		slack.MsgOptionAsUser(msg.AsUser),
-		slack.MsgOptionEnableLinkUnfurl(),
-	}
-
 	_, _, _, err := client.UpdateMessage(
 		channelID,
 		timestamp,
-		opts...,
+		getCommonOpts(msg)...,
 	)
 
 	return err

--- a/mock_resp.go
+++ b/mock_resp.go
@@ -1,6 +1,6 @@
 package utils
 
-const channelCreateResp = `{
+const mockChannelCreateResp = `{
     "ok": true,
     "channel": {
         "id": "C0DEL09A5",
@@ -37,7 +37,7 @@ const channelCreateResp = `{
     }
 }`
 
-const inviteMembersResp = `{
+const mockInviteMembersResp = `{
     "ok": true,
     "channel": {
         "id": "C1H9RESGL",
@@ -81,7 +81,7 @@ const inviteMembersResp = `{
     }
 }`
 
-const postMsgResp = `{
+const mockPostMsgResp = `{
     "ok": true,
     "channel": "C1H9RESGL",
     "ts": "1503435956.000247",
@@ -102,7 +102,7 @@ const postMsgResp = `{
     }
 }`
 
-const updateMsgResp = `{
+const mockUpdateMsgResp = `{
     "ok": true,
     "channel": "C1H9RESGL",
     "ts": "1503435956.000400",
@@ -123,7 +123,7 @@ const updateMsgResp = `{
     }
 }`
 
-const channelInfoResp = `{
+const mockChannelInfoResp = `{
     "ok": true,
     "channel": {
         "id": "C1H9RESGL",
@@ -177,7 +177,7 @@ const channelInfoResp = `{
     }
 }`
 
-const usersListResp = `{
+const mockUsersListResp = `{
     "ok": true,
     "members": [
         {
@@ -264,11 +264,7 @@ const usersListResp = `{
     }
 }`
 
-const channelsLeaveResp = `{
-    "ok": true
-}`
-
-const channelsArchiveResp = `{
+const mockSuccessResp = `{
     "ok": true
 }`
 
@@ -277,48 +273,48 @@ hoge@email.com
 foo@email.com
 bar@email.com`
 
-const channelCreateErrResp = `{
+const mockChannelCreateErrResp = `{
     "ok": false,
     "error": "invalid_name_specials",
     "detail": "Value passed for 'name' contained unallowed special characters."
 }`
 
-const inviteMembersErrResp = `{
+const mockInviteMembersErrResp = `{
     "ok": false,
     "error": "cant_invite"
 }`
 
-const cantInviteSelfErrResp = `{
+const mockCantInviteSelfErrResp = `{
     "ok": false,
     "error": "cant_invite_self"
 }`
 
-const postMsgErrResp = `{
+const mockPostMsgErrResp = `{
     "ok": false,
     "error": "too_many_attachments"
 }`
 
-const channelInfoErrResp = `{
+const mockChannelInfoErrResp = `{
     "ok": false,
     "error": "channel_not_found"
 }`
 
-const usersListErrResp = `{
+const mockUsersListErrResp = `{
     "ok": false,
     "error": "invalid_cursor"
 }`
 
-const channelsLeaveErrResp = `{
+const mockChannelsLeaveErrResp = `{
     "ok": false,
     "error": "invalid_auth"
 }`
 
-const channelsArchiveErrResp = `{
+const mockChannelsArchiveErrResp = `{
     "ok": false,
     "error": "invalid_auth"
 }`
 
-const channelAlreadyArchivedErrResp = `{
+const mockChannelAlreadyArchivedErrResp = `{
     "ok": false,
     "error": "already_archived"
 }`

--- a/user_test.go
+++ b/user_test.go
@@ -19,13 +19,13 @@ func TestEmailsToSlackIDs(t *testing.T) {
 	}{
 		{
 			description:   "successful retrieval of member emails",
-			respUsersList: []byte(usersListResp),
+			respUsersList: []byte(mockUsersListResp),
 			emails:        []string{"spengler@ghostbusters.example.com", "glenda@south.oz.coven"},
 			wantIDs:       []string{"U0G9QF9C6", "W07QCRPA4"},
 		},
 		{
 			description:   "failure to retrieve users list",
-			respUsersList: []byte(usersListErrResp),
+			respUsersList: []byte(mockUsersListErrResp),
 			wantErr:       "invalid_cursor",
 		},
 	}
@@ -45,23 +45,19 @@ func TestEmailsToSlackIDs(t *testing.T) {
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
-				return
 			}
 
 			if tc.wantErr != "" {
 				if err == nil {
 					t.Fatal("expected error but did not receive one")
-					return
 				}
 				if err.Error() != tc.wantErr {
 					t.Fatalf("expected to receive error: %s, got: %s", tc.wantErr, err)
-					return
 				}
 			}
 
 			if len(ids) != len(tc.wantIDs) {
 				t.Fatalf("expected to receive %v ids, got %v instead", len(tc.wantIDs), len(ids))
-				return
 			}
 
 			for i, id := range ids {
@@ -83,13 +79,13 @@ func TestEmailsToSlackIDsInclusive(t *testing.T) {
 	}{
 		{
 			description:   "successful retrieval of member emails",
-			respUsersList: []byte(usersListResp),
+			respUsersList: []byte(mockUsersListResp),
 			emails:        []string{"spengler@ghostbusters.example.com", "glenda@south.oz.coven"},
 			wantIDs:       []string{"U0G9QF9C6", "W07QCRPA4"},
 		},
 		{
 			description:   "failure to retrieve users list",
-			respUsersList: []byte(usersListErrResp),
+			respUsersList: []byte(mockUsersListErrResp),
 			wantErr:       "invalid_cursor",
 		},
 	}
@@ -109,30 +105,25 @@ func TestEmailsToSlackIDsInclusive(t *testing.T) {
 
 			if tc.wantErr == "" && err != nil {
 				t.Fatalf("unexpected error: %v", err)
-				return
 			}
 
 			if tc.wantErr != "" {
 				if err == nil {
 					t.Fatal("expected error but did not receive one")
-					return
 				}
 				if err.Error() != tc.wantErr {
 					t.Fatalf("expected to receive error: %s, got: %s", tc.wantErr, err)
-					return
 				}
 				return
 			}
 
 			if len(idEmailPairs) != len(tc.wantIDs) {
 				t.Fatalf("expected to receive %v ids, got %v instead", len(tc.wantIDs), len(idEmailPairs))
-				return
 			}
 
 			for i, idEmailPair := range idEmailPairs {
 				if tc.emails[i] != idEmailPair[0] {
 					t.Fatalf("expected email: %v, got: %v", tc.emails[1], idEmailPair[0])
-					return
 				}
 				if tc.wantIDs[i] != idEmailPair[1] {
 					t.Fatalf("expected id: %v, got: %v", tc.wantIDs[1], idEmailPair[1])

--- a/verify_test.go
+++ b/verify_test.go
@@ -41,7 +41,6 @@ func TestVerifyCallbackMsg(t *testing.T) {
 
 			if tc.wantErr != "" && err == nil {
 				t.Fatal("expected timestamp too old error, didn't receive one")
-				return
 			}
 
 			if err.Error() != tc.wantErr && !strings.Contains(err.Error(), tc.wantErr) {
@@ -83,7 +82,6 @@ func TestVerifySlashCmd(t *testing.T) {
 
 			if tc.wantErr != "" && err == nil {
 				t.Fatal("expected timestamp too old error, didn't receive one")
-				return
 			}
 
 			if err.Error() != tc.wantErr && !strings.Contains(err.Error(), tc.wantErr) {


### PR DESCRIPTION
## Summary
- Remove redundant returns in tests :man_facepalming: 
- Update mock test const names 
- Simplify response values for message functions
- Add two new methods:
  - `DeleteMsg`
  - `PostEphemeralMsg` 