### PR TITLE
Ignore default style

### DIFF
--- a/block.go
+++ b/block.go
@@ -30,7 +30,9 @@ func NewTextBlock(body string, accessory *slack.Accessory) *slack.SectionBlock {
 func NewButton(actionID, value string, text string, style slack.Style) *slack.ButtonBlockElement {
 	btnText := slack.NewTextBlockObject(slack.PlainTextType, text, false, false)
 	btn := slack.NewButtonBlockElement(actionID, value, btnText)
-	btn.WithStyle(style)
+	if style != slack.StyleDefault {
+		btn.WithStyle(style)
+	}
 	return btn
 }
 

--- a/block_test.go
+++ b/block_test.go
@@ -29,14 +29,13 @@ func TestNewButton(t *testing.T) {
 		wantButton  *slack.ButtonBlockElement
 	}{
 		{
-			description: "returns default style button",
+			description: "ignores default style",
 			style:       slack.StyleDefault,
 			wantButton: &slack.ButtonBlockElement{
 				Type:     slack.METButton,
 				ActionID: mockActionID,
 				Text:     mockTextObj,
 				Value:    mockValue,
-				Style:    slack.StyleDefault,
 			},
 		},
 		{
@@ -185,7 +184,6 @@ func TestTextBlock(t *testing.T) {
 						ActionID: mockActionID,
 						Text:     mockTextObj,
 						Value:    mockValue,
-						Style:    slack.StyleDefault,
 					},
 				},
 			},


### PR DESCRIPTION
Not sure if the issue is in `slack-go` or Slack itself, but explicitly setting default style causes `internal_error`. Doing nothing gives us a default style button anyways, so skip setting style